### PR TITLE
Make firewall and firewall resources location based

### DIFF
--- a/config/tf_generator_config.yml
+++ b/config/tf_generator_config.yml
@@ -3,15 +3,15 @@ provider:
 data_sources:
   firewall:
     read:
-      path: /project/{project_id}/firewall/{firewall_id}
+      path: /project/{project_id}/location/{location}/firewall/{firewall_name}
       method: GET
     schema:
       attributes:
         aliases:
-          firewall_id: id
+          firewall_name: name
   firewall_rule:
     read:
-      path: /project/{project_id}/firewall/{firewall_id}/firewall-rule/{firewall_rule_id}
+      path: /project/{project_id}/location/{location}/firewall/{firewall_name}/firewall-rule/{firewall_rule_id}
       method: GET
     schema:
       attributes:
@@ -53,21 +53,21 @@ data_sources:
 resources:
   firewall:
     create:
-      path: /project/{project_id}/firewall
+      path: /project/{project_id}/location/{location}/firewall/{firewall_name}
       method: POST
     read:
-      path: /project/{project_id}/firewall/{firewall_id}
+      path: /project/{project_id}/location/{location}/firewall/{firewall_name}
       method: GET
     schema:
       attributes:
         aliases:
-          firewall_id: id
+          firewall_name: name
   firewall_rule:
     create:
-      path: /project/{project_id}/firewall/{firewall_id}/firewall-rule
+      path: /project/{project_id}/location/{location}/firewall/{firewall_name}/firewall-rule
       method: POST
     read:
-      path: /project/{project_id}/firewall/{firewall_id}/firewall-rule/{firewall_rule_id}
+      path: /project/{project_id}/location/{location}/firewall/{firewall_name}/firewall-rule/{firewall_rule_id}
       method: GET
     schema:
       attributes:

--- a/config/ubicloud_openapi.yml
+++ b/config/ubicloud_openapi.yml
@@ -722,10 +722,11 @@ paths:
           description: Unauthorized
 
 # FIREWALL RULES
-  /project/{project_id}/firewall/{firewall_id}/firewall-rule:
+  /project/{project_id}/location/{location}/firewall/{firewall_name}/firewall-rule:
     parameters:
       - $ref: '#/components/parameters/project_id'
-      - $ref: '#/components/parameters/firewall_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/firewall_name'
     post:
       tags: 
         - Firewall Rule
@@ -738,10 +739,6 @@ paths:
             schema:
               type: object
               properties:
-                project_id:
-                  type: string
-                firewall_id:
-                  type: string
                 cidr:
                   type: string
                   description: CIDR of the firewall rule
@@ -761,10 +758,11 @@ paths:
           description: Invalid request
         '401':
           description: Unauthorized
-  /project/{project_id}/firewall/{firewall_id}/firewall-rule/{firewall_rule_id}:
+  /project/{project_id}/location/{location}/firewall/{firewall_name}/firewall-rule/{firewall_rule_id}:
     parameters:
       - $ref: '#/components/parameters/project_id'
-      - $ref: '#/components/parameters/firewall_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/firewall_name'
       - $ref: '#/components/parameters/firewall_rule_id'    
     get:
       tags: 
@@ -792,29 +790,26 @@ paths:
           description: Unauthorized
 
 # FIREWALL
-  /project/{project_id}/firewall:
+  /project/{project_id}/location/{location}/firewall/{firewall_name}:
     parameters:
       - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/firewall_name'
     post:
       tags: 
         - Firewall
       summary: Create a new firewall
       operationId: createFirewall
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
               type: object
               properties:
-                name:
-                  type: string
-                  description: Name of the firewall
                 description:
                   type: string
                   description: Description of the firewall
-              required:
-                - name
       responses:
         '200':
           description: Firewall created successfully
@@ -826,10 +821,6 @@ paths:
           description: Invalid request
         '401':
           description: Unauthorized
-  /project/{project_id}/firewall/{firewall_id}:
-    parameters:
-      - $ref: '#/components/parameters/project_id'
-      - $ref: '#/components/parameters/firewall_id'  
     get:
       tags: 
         - Firewall
@@ -975,6 +966,9 @@ components:
         name:
           type: string
           description: Name of the firewall
+        location:
+          type: string
+          description: Location of the firewall
         description:
           type: string
           description: Description of the firewall
@@ -1155,6 +1149,13 @@ components:
       schema:
         type: string
       description: ID of the firewall
+    firewall_name:
+      name: firewall_name
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Name of the firewall
     firewall_rule_id:
       name: firewall_rule_id
       in: path

--- a/docs/data-sources/firewall.md
+++ b/docs/data-sources/firewall.md
@@ -21,7 +21,8 @@ variable "project_id" {
 
 data "ubicloud_firewall" "example" {
   project_id = var.project_id
-  id         = "fwk5tac59hjp4mgx1w2s0r4a6v"
+  location   = "eu-central-h1"
+  name       = "tf-testacc"
 }
 
 output "example_firewall" {
@@ -34,14 +35,15 @@ output "example_firewall" {
 
 ### Required
 
-- `id` (String) ID of the firewall
+- `location` (String) The Ubicloud location/region
+- `name` (String) Name of the firewall
 - `project_id` (String) ID of the project
 
 ### Read-Only
 
 - `description` (String) Description of the firewall
 - `firewall_rules` (Attributes List) List of firewall rules (see [below for nested schema](#nestedatt--firewall_rules))
-- `name` (String) Name of the firewall
+- `id` (String) ID of the firewall
 
 <a id="nestedatt--firewall_rules"></a>
 ### Nested Schema for `firewall_rules`

--- a/docs/data-sources/firewall_rule.md
+++ b/docs/data-sources/firewall_rule.md
@@ -14,9 +14,10 @@ Get information about a Ubicloud firewall rule.
 
 ```terraform
 data "ubicloud_firewall_rule" "example" {
-  project_id  = "pj01qy4sty1j7nycv8hfqmgy6t"
-  firewall_id = "fwk5tac59hjp4mgx1w2s0r4a6v"
-  id          = "fr9wf3tra2r23nvsrcm5jkxb8d"
+  project_id    = "pj01qy4sty1j7nycv8hfqmgy6t"
+  location      = "eu-central-h1"
+  firewall_name = "tf-testacc"
+  id            = "fr9wf3tra2r23nvsrcm5jkxb8d"
 }
 output "test_firewall" {
   value = data.ubicloud_firewall_rule.example
@@ -28,8 +29,9 @@ output "test_firewall" {
 
 ### Required
 
-- `firewall_id` (String) ID of the firewall
+- `firewall_name` (String) Name of the firewall
 - `id` (String) ID of the firewall rule
+- `location` (String) The Ubicloud location/region
 - `project_id` (String) ID of the project
 
 ### Read-Only

--- a/docs/data-sources/private_subnet.md
+++ b/docs/data-sources/private_subnet.md
@@ -60,6 +60,7 @@ Read-Only:
 - `description` (String) Description of the firewall
 - `firewall_rules` (Attributes List) List of firewall rules (see [below for nested schema](#nestedatt--firewalls--firewall_rules))
 - `id` (String) ID of the firewall
+- `location` (String) Location of the firewall
 - `name` (String) Name of the firewall
 
 <a id="nestedatt--firewalls--firewall_rules"></a>

--- a/docs/data-sources/vm.md
+++ b/docs/data-sources/vm.md
@@ -67,6 +67,7 @@ Read-Only:
 - `description` (String) Description of the firewall
 - `firewall_rules` (Attributes List) List of firewall rules (see [below for nested schema](#nestedatt--firewalls--firewall_rules))
 - `id` (String) ID of the firewall
+- `location` (String) Location of the firewall
 - `name` (String) Name of the firewall
 
 <a id="nestedatt--firewalls--firewall_rules"></a>

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -27,15 +27,17 @@ variable "location" {
 
 resource "ubicloud_firewall" "example" {
   project_id  = var.project_id
+  location    = var.location
   name        = "example-firewall"
   description = "Description of firewall"
 }
 
 resource "ubicloud_firewall_rule" "ssh" {
-  project_id  = var.project_id
-  firewall_id = ubicloud_firewall.example.id
-  cidr        = "0.0.0.0/0"
-  port_range  = "22..22"
+  project_id    = var.project_id
+  location      = var.location
+  firewall_name = ubicloud_firewall.example.name
+  cidr          = "0.0.0.0/0"
+  port_range    = "22..22"
 }
 ```
 
@@ -44,6 +46,7 @@ resource "ubicloud_firewall_rule" "ssh" {
 
 ### Required
 
+- `location` (String) Location of the firewall
 - `name` (String) Name of the firewall
 - `project_id` (String) ID of the project
 
@@ -70,5 +73,5 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-terraform import ubicloud_firewall.example <project_id>,<firewall_id>
+terraform import ubicloud_firewall.example <project_id>,<location>,<firewall_name>
 ```

--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -14,10 +14,11 @@ Provides a Ubicloud FirewallRule resource. This can be used to create and delete
 
 ```terraform
 resource "ubicloud_firewall_rule" "ssh" {
-  project_id  = "pj01qy4sty1j7nycv8hfqmgy6t"
-  firewall_id = "fwk5tac59hjp4mgx1w2s0r4a6v"
-  cidr        = "0.0.0.0/0"
-  port_range  = "22..22"
+  project_id    = "pj01qy4sty1j7nycv8hfqmgy6t"
+  location      = "eu-central-1"
+  firewall_name = "tf-testacc"
+  cidr          = "0.0.0.0/0"
+  port_range    = "22..22"
 }
 ```
 
@@ -30,7 +31,8 @@ resource "ubicloud_firewall_rule" "ssh" {
 
 ### Optional
 
-- `firewall_id` (String) ID of the firewall
+- `firewall_name` (String) Name of the firewall
+- `location` (String) The Ubicloud location/region
 - `port_range` (String) Port range of the firewall rule
 - `project_id` (String) ID of the project
 
@@ -43,5 +45,5 @@ resource "ubicloud_firewall_rule" "ssh" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import ubicloud_firewall_rule.example <project_id>,<firewall_id>,<rule_id>
+terraform import ubicloud_firewall_rule.example <project_id>,<location>,<firewall_name>,<rule_id>
 ```

--- a/docs/resources/private_subnet.md
+++ b/docs/resources/private_subnet.md
@@ -61,6 +61,7 @@ Read-Only:
 - `description` (String) Description of the firewall
 - `firewall_rules` (Attributes List) List of firewall rules (see [below for nested schema](#nestedatt--firewalls--firewall_rules))
 - `id` (String) ID of the firewall
+- `location` (String) Location of the firewall
 - `name` (String) Name of the firewall
 
 <a id="nestedatt--firewalls--firewall_rules"></a>

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -33,15 +33,17 @@ variable "ssh_key" {
 
 resource "ubicloud_firewall" "example" {
   project_id  = var.project_id
+  location    = var.location
   name        = "example-firewall"
   description = "Example firewall"
 }
 
 resource "ubicloud_firewall_rule" "ssh" {
-  project_id  = var.project_id
-  firewall_id = ubicloud_firewall.example.id
-  cidr        = "0.0.0.0/0"
-  port_range  = "22..22"
+  project_id    = var.project_id
+  location      = var.location
+  firewall_name = ubicloud_firewall.example.name
+  cidr          = "0.0.0.0/0"
+  port_range    = "22..22"
 }
 
 resource "ubicloud_private_subnet" "example" {
@@ -105,6 +107,7 @@ Read-Only:
 - `description` (String) Description of the firewall
 - `firewall_rules` (Attributes List) List of firewall rules (see [below for nested schema](#nestedatt--firewalls--firewall_rules))
 - `id` (String) ID of the firewall
+- `location` (String) Location of the firewall
 - `name` (String) Name of the firewall
 
 <a id="nestedatt--firewalls--firewall_rules"></a>

--- a/examples/data-sources/ubicloud_firewall/data-source.tf
+++ b/examples/data-sources/ubicloud_firewall/data-source.tf
@@ -7,7 +7,8 @@ variable "project_id" {
 
 data "ubicloud_firewall" "example" {
   project_id = var.project_id
-  id         = "fwk5tac59hjp4mgx1w2s0r4a6v"
+  location   = "eu-central-h1"
+  name       = "tf-testacc"
 }
 
 output "example_firewall" {

--- a/examples/data-sources/ubicloud_firewall_rule/data-source.tf
+++ b/examples/data-sources/ubicloud_firewall_rule/data-source.tf
@@ -1,7 +1,8 @@
 data "ubicloud_firewall_rule" "example" {
-  project_id  = "pj01qy4sty1j7nycv8hfqmgy6t"
-  firewall_id = "fwk5tac59hjp4mgx1w2s0r4a6v"
-  id          = "fr9wf3tra2r23nvsrcm5jkxb8d"
+  project_id    = "pj01qy4sty1j7nycv8hfqmgy6t"
+  location      = "eu-central-h1"
+  firewall_name = "tf-testacc"
+  id            = "fr9wf3tra2r23nvsrcm5jkxb8d"
 }
 output "test_firewall" {
   value = data.ubicloud_firewall_rule.example

--- a/examples/resources/ubicloud_firewall/import.sh
+++ b/examples/resources/ubicloud_firewall/import.sh
@@ -1,1 +1,1 @@
-terraform import ubicloud_firewall.example <project_id>,<firewall_id>
+terraform import ubicloud_firewall.example <project_id>,<location>,<firewall_name>

--- a/examples/resources/ubicloud_firewall/resource.tf
+++ b/examples/resources/ubicloud_firewall/resource.tf
@@ -12,13 +12,15 @@ variable "location" {
 
 resource "ubicloud_firewall" "example" {
   project_id  = var.project_id
+  location    = var.location
   name        = "example-firewall"
   description = "Description of firewall"
 }
 
 resource "ubicloud_firewall_rule" "ssh" {
-  project_id  = var.project_id
-  firewall_id = ubicloud_firewall.example.id
-  cidr        = "0.0.0.0/0"
-  port_range  = "22..22"
+  project_id    = var.project_id
+  location      = var.location
+  firewall_name = ubicloud_firewall.example.name
+  cidr          = "0.0.0.0/0"
+  port_range    = "22..22"
 }

--- a/examples/resources/ubicloud_firewall_rule/import.sh
+++ b/examples/resources/ubicloud_firewall_rule/import.sh
@@ -1,1 +1,1 @@
-terraform import ubicloud_firewall_rule.example <project_id>,<firewall_id>,<rule_id>
+terraform import ubicloud_firewall_rule.example <project_id>,<location>,<firewall_name>,<rule_id>

--- a/examples/resources/ubicloud_firewall_rule/resource.tf
+++ b/examples/resources/ubicloud_firewall_rule/resource.tf
@@ -1,7 +1,8 @@
 
 resource "ubicloud_firewall_rule" "ssh" {
-  project_id  = "pj01qy4sty1j7nycv8hfqmgy6t"
-  firewall_id = "fwk5tac59hjp4mgx1w2s0r4a6v"
-  cidr        = "0.0.0.0/0"
-  port_range  = "22..22"
+  project_id    = "pj01qy4sty1j7nycv8hfqmgy6t"
+  location      = "eu-central-1"
+  firewall_name = "tf-testacc"
+  cidr          = "0.0.0.0/0"
+  port_range    = "22..22"
 }

--- a/examples/resources/ubicloud_vm/resource.tf
+++ b/examples/resources/ubicloud_vm/resource.tf
@@ -18,15 +18,17 @@ variable "ssh_key" {
 
 resource "ubicloud_firewall" "example" {
   project_id  = var.project_id
+  location    = var.location
   name        = "example-firewall"
   description = "Example firewall"
 }
 
 resource "ubicloud_firewall_rule" "ssh" {
-  project_id  = var.project_id
-  firewall_id = ubicloud_firewall.example.id
-  cidr        = "0.0.0.0/0"
-  port_range  = "22..22"
+  project_id    = var.project_id
+  location      = var.location
+  firewall_name = ubicloud_firewall.example.name
+  cidr          = "0.0.0.0/0"
+  port_range    = "22..22"
 }
 
 resource "ubicloud_private_subnet" "example" {

--- a/internal/provider/firewall_datasource.go
+++ b/internal/provider/firewall_datasource.go
@@ -64,7 +64,7 @@ func (d *firewallDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading firewall: %s", firewallDataSourceLogIdentifier(&state)))
-	firewallResp, err := d.uc.client.GetFirewallDetailsWithResponse(ctx, state.ProjectId.ValueString(), state.Id.ValueString())
+	firewallResp, err := d.uc.client.GetFirewallDetailsWithResponse(ctx, state.ProjectId.ValueString(), state.Location.ValueString(), state.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error reading firewall: %s", firewallDataSourceLogIdentifier(&state)),
@@ -83,6 +83,7 @@ func (d *firewallDataSource) Read(ctx context.Context, req datasource.ReadReques
 	assignStr(firewallResp.JSON200.Id, &state.Id)
 	assignStr(firewallResp.JSON200.Name, &state.Name)
 	assignStr(firewallResp.JSON200.Description, &state.Description)
+	assignStr(firewallResp.JSON200.Location, &state.Location)
 
 	firewallRulesListValue, fwRulesDiags := GetFirewallRulesState(ctx, firewallResp.JSON200.FirewallRules)
 	resp.Diagnostics.Append(fwRulesDiags...)
@@ -112,6 +113,7 @@ func GetFirewallsState(ctx context.Context, firewalls *[]ubicloud_client.Firewal
 
 			fw := datasource_vm.NewFirewallsValueMust(firewallsValue.AttributeTypes(ctx), map[string]attr.Value{
 				"id":             types.StringValue(*f.Id),
+				"location":       types.StringValue(*f.Location),
 				"name":           types.StringValue(*f.Name),
 				"description":    types.StringValue(*f.Description),
 				"firewall_rules": fwRules,
@@ -131,5 +133,5 @@ func GetFirewallsState(ctx context.Context, firewalls *[]ubicloud_client.Firewal
 }
 
 func firewallDataSourceLogIdentifier(state *datasource_firewall.FirewallModel) string {
-	return fmt.Sprintf("project_id=%s, firewall_id=%s", state.ProjectId.ValueString(), state.Id.ValueString())
+	return fmt.Sprintf("project_id=%s, location=%s, firewall_name=%s", state.ProjectId.ValueString(), state.Location.ValueString(), state.Name.ValueString())
 }

--- a/internal/provider/firewall_datasource_test.go
+++ b/internal/provider/firewall_datasource_test.go
@@ -17,17 +17,20 @@ func TestAccFirewallDataSource(t *testing.T) {
 					fmt.Sprintf(`
         resource "ubicloud_firewall" "testacc" {
           project_id  = "%s"
+          location    = "%s"
           name        = "tf-testacc"
           description = "Terraform acceptance testing"
         }
         
         data "ubicloud_firewall" "testacc" {
           project_id = ubicloud_firewall.testacc.project_id
-          id = ubicloud_firewall.testacc.id
-        }`, GetTestAccProjectId()),
+          location   = ubicloud_firewall.testacc.location
+          name       = ubicloud_firewall.testacc.name
+        }`, GetTestAccProjectId(), GetTestAccLocation()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ubicloud_firewall.testacc", "id"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "project_id", GetTestAccProjectId()),
+					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "location", GetTestAccLocation()),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "name", "tf-testacc"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "description", "Terraform acceptance testing"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "firewall_rules.#", "0"),

--- a/internal/provider/firewall_resource_test.go
+++ b/internal/provider/firewall_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccFirewallResource(t *testing.T) {
@@ -17,12 +18,14 @@ func TestAccFirewallResource(t *testing.T) {
 					fmt.Sprintf(`
         resource "ubicloud_firewall" "testacc" {
           project_id  = "%s"
+          location    = "%s"
           name        = "tf-testacc"
           description = "Terraform acceptance testing"
-        }`, GetTestAccProjectId()),
+        }`, GetTestAccProjectId(), GetTestAccLocation()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ubicloud_firewall.testacc", "id"),
 					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "project_id", GetTestAccProjectId()),
+					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "location", GetTestAccLocation()),
 					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "name", "tf-testacc"),
 					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "description", "Terraform acceptance testing"),
 					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "firewall_rules.#", "0"),
@@ -32,8 +35,9 @@ func TestAccFirewallResource(t *testing.T) {
 			{
 				ResourceName:        "ubicloud_firewall.testacc",
 				ImportState:         true,
-				ImportStateIdPrefix: fmt.Sprintf("%s,", GetTestAccProjectId()),
-				ImportStateVerify:   true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					return fmt.Sprintf("%s,%s,%s", GetTestAccProjectId(), GetTestAccLocation(), "tf-testacc"), nil
+				},
 			},
 		},
 	})

--- a/internal/provider/firewall_rule_datasource.go
+++ b/internal/provider/firewall_rule_datasource.go
@@ -66,7 +66,7 @@ func (d *firewallRuleDataSource) Read(ctx context.Context, req datasource.ReadRe
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading firewall rule: %s", firewallRuleDataSourceLogIdentifier(&state)))
-	firewallRuleResp, err := d.uc.client.GetFirewallRuleDetailsWithResponse(ctx, state.ProjectId.ValueString(), state.FirewallId.ValueString(), state.Id.ValueString())
+	firewallRuleResp, err := d.uc.client.GetFirewallRuleDetailsWithResponse(ctx, state.ProjectId.ValueString(), state.Location.ValueString(), state.FirewallName.ValueString(), state.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error reading firewall rule: %s", firewallRuleDataSourceLogIdentifier(&state)),
@@ -117,5 +117,5 @@ func GetFirewallRulesState(ctx context.Context, firewallRules *[]ubicloud_client
 }
 
 func firewallRuleDataSourceLogIdentifier(state *datasource_firewall_rule.FirewallRuleModel) string {
-	return fmt.Sprintf("project_id=%s, firewall_id=%s, rule_id=%s", state.ProjectId.ValueString(), state.FirewallId.ValueString(), state.Id.ValueString())
+	return fmt.Sprintf("project_id=%s, location=%s, firewall_name=%s, rule_id=%s", state.ProjectId.ValueString(), state.Location.ValueString(), state.FirewallName.ValueString(), state.Id.ValueString())
 }

--- a/internal/provider/firewall_rule_datasource_test.go
+++ b/internal/provider/firewall_rule_datasource_test.go
@@ -11,41 +11,47 @@ func TestAccFirewallRuleDataSource(t *testing.T) {
 	resourceConfig := fmt.Sprintf(`
     resource "ubicloud_firewall" "testacc" {
       project_id  = "%s"
+      location    = "%s"
       name        = "tf-testacc"
       description = "Terraform acceptance testing"
     }
 
     resource "ubicloud_firewall_rule" "testaccfwr1" {
-      project_id  = ubicloud_firewall.testacc.project_id
-      firewall_id = ubicloud_firewall.testacc.id
-      cidr        = "1.2.3.0/24"
-      port_range  = "80..8080"
+      project_id    = ubicloud_firewall.testacc.project_id
+      location      = ubicloud_firewall.testacc.location
+      firewall_name = ubicloud_firewall.testacc.name
+      cidr          = "1.2.3.0/24"
+      port_range    = "80..8080"
     }
 
     resource "ubicloud_firewall_rule" "testaccfwr2" {
-      project_id  = ubicloud_firewall.testacc.project_id
-      firewall_id = ubicloud_firewall.testacc.id
-      cidr        = "0.0.0.0/0"
-      port_range  = "22..22"
+      project_id    = ubicloud_firewall.testacc.project_id
+      location      = ubicloud_firewall.testacc.location
+      firewall_name = ubicloud_firewall.testacc.name
+      cidr          = "0.0.0.0/0"
+      port_range    = "22..22"
     }			
-    `, GetTestAccProjectId())
+    `, GetTestAccProjectId(), GetTestAccLocation())
 
 	dataConfig := `
     data "ubicloud_firewall_rule" "testaccfwr1" {
-      project_id = ubicloud_firewall.testacc.project_id
-      firewall_id = ubicloud_firewall.testacc.id
-      id = ubicloud_firewall_rule.testaccfwr1.id
+      project_id    = ubicloud_firewall.testacc.project_id
+      location      = ubicloud_firewall.testacc.location
+      firewall_name = ubicloud_firewall.testacc.name
+      id            = ubicloud_firewall_rule.testaccfwr1.id
     }
 
     data "ubicloud_firewall_rule" "testaccfwr2" {
-      project_id = ubicloud_firewall.testacc.project_id
-      firewall_id = ubicloud_firewall.testacc.id
-      id = ubicloud_firewall_rule.testaccfwr2.id
+      project_id    = ubicloud_firewall.testacc.project_id
+      location      = ubicloud_firewall.testacc.location
+      firewall_name = ubicloud_firewall.testacc.name
+      id            = ubicloud_firewall_rule.testaccfwr2.id
     }
       
     data "ubicloud_firewall" "testacc" {
       project_id = ubicloud_firewall.testacc.project_id
-      id = ubicloud_firewall.testacc.id
+      location   = ubicloud_firewall.testacc.location
+      name       = ubicloud_firewall.testacc.name
     }
     `
 
@@ -61,19 +67,22 @@ func TestAccFirewallRuleDataSource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ubicloud_firewall.testacc", "id"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "project_id", GetTestAccProjectId()),
+					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "location", GetTestAccLocation()),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "name", "tf-testacc"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "description", "Terraform acceptance testing"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall.testacc", "firewall_rules.#", "2"),
 
 					resource.TestCheckResourceAttrSet("data.ubicloud_firewall_rule.testaccfwr1", "id"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall_rule.testaccfwr1", "project_id", GetTestAccProjectId()),
-					resource.TestCheckResourceAttrSet("data.ubicloud_firewall_rule.testaccfwr1", "firewall_id"),
+					resource.TestCheckResourceAttr("data.ubicloud_firewall_rule.testaccfwr1", "location", GetTestAccLocation()),
+					resource.TestCheckResourceAttrSet("data.ubicloud_firewall_rule.testaccfwr1", "firewall_name"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall_rule.testaccfwr1", "cidr", "1.2.3.0/24"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall_rule.testaccfwr1", "port_range", "80..8080"),
 
 					resource.TestCheckResourceAttrSet("data.ubicloud_firewall_rule.testaccfwr2", "id"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall_rule.testaccfwr2", "project_id", GetTestAccProjectId()),
-					resource.TestCheckResourceAttrSet("data.ubicloud_firewall_rule.testaccfwr2", "firewall_id"),
+					resource.TestCheckResourceAttr("data.ubicloud_firewall_rule.testaccfwr2", "location", GetTestAccLocation()),
+					resource.TestCheckResourceAttrSet("data.ubicloud_firewall_rule.testaccfwr2", "firewall_name"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall_rule.testaccfwr2", "cidr", "0.0.0.0/0"),
 					resource.TestCheckResourceAttr("data.ubicloud_firewall_rule.testaccfwr2", "port_range", "22..22"),
 				),

--- a/internal/provider/firewall_rule_resource_test.go
+++ b/internal/provider/firewall_rule_resource_test.go
@@ -12,17 +12,19 @@ func TestAccFirewallRuleResource(t *testing.T) {
 	resourceConfig := fmt.Sprintf(`
     resource "ubicloud_firewall" "testacc" {
       project_id  = "%s"
+      location    = "%s"
       name        = "tf-testacc"
       description = "Terraform acceptance testing"
     }
 
     resource "ubicloud_firewall_rule" "testaccfwr1" {
       project_id  = ubicloud_firewall.testacc.project_id
-      firewall_id = ubicloud_firewall.testacc.id
+      location    = ubicloud_firewall.testacc.location
+      firewall_name = ubicloud_firewall.testacc.name
       cidr        = "0.0.0.0/0"
       port_range  = "22..22"
     }			
-    `, GetTestAccProjectId())
+    `, GetTestAccProjectId(), GetTestAccLocation())
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -37,13 +39,14 @@ func TestAccFirewallRuleResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ubicloud_firewall.testacc", "id"),
 					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "project_id", GetTestAccProjectId()),
+					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "location", GetTestAccLocation()),
 					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "name", "tf-testacc"),
 					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "description", "Terraform acceptance testing"),
 					resource.TestCheckResourceAttr("ubicloud_firewall.testacc", "firewall_rules.#", "1"),
 
 					resource.TestCheckResourceAttrSet("ubicloud_firewall_rule.testaccfwr1", "id"),
 					resource.TestCheckResourceAttr("ubicloud_firewall_rule.testaccfwr1", "project_id", GetTestAccProjectId()),
-					resource.TestCheckResourceAttrSet("ubicloud_firewall_rule.testaccfwr1", "firewall_id"),
+					resource.TestCheckResourceAttrSet("ubicloud_firewall_rule.testaccfwr1", "firewall_name"),
 					resource.TestCheckResourceAttr("ubicloud_firewall_rule.testaccfwr1", "cidr", "0.0.0.0/0"),
 					resource.TestCheckResourceAttr("ubicloud_firewall_rule.testaccfwr1", "port_range", "22..22"),
 				),
@@ -70,6 +73,6 @@ func importStateIdFunc(fwr string) resource.ImportStateIdFunc {
 		if rs.Primary.ID == "" {
 			return "", fmt.Errorf("No Record ID is set")
 		}
-		return fmt.Sprintf("%s,%s,%s", GetTestAccProjectId(), rs.Primary.Attributes["firewall_id"], rs.Primary.ID), nil
+		return fmt.Sprintf("%s,%s,%s,%s", GetTestAccProjectId(), rs.Primary.Attributes["location"], rs.Primary.Attributes["firewall_name"], rs.Primary.ID), nil
 	}
 }


### PR DESCRIPTION
Making firewall and firewall rule resources location based. Location based resources can be managed by either their id or name, with this PR adding the name support.