### PR TITLE
Use StringPointerValue instead of StringValue

### DIFF
--- a/internal/provider/firewall_datasource.go
+++ b/internal/provider/firewall_datasource.go
@@ -102,7 +102,7 @@ func GetFirewallsState(ctx context.Context, firewalls *[]ubicloud_client.Firewal
 	firewallsValue := datasource_vm.FirewallsValue{}
 	var firewallsValues []datasource_vm.FirewallsValue
 	firewallRulesValue := datasource_vm.FirewallRulesValue{}
-	if *firewalls != nil && len(*firewalls) > 0 {
+	if firewalls != nil && len(*firewalls) > 0 {
 		for _, f := range *firewalls {
 
 			fwRules, fwRulesDiag := GetFirewallRulesState(ctx, f.FirewallRules)
@@ -112,10 +112,10 @@ func GetFirewallsState(ctx context.Context, firewalls *[]ubicloud_client.Firewal
 			}
 
 			fw := datasource_vm.NewFirewallsValueMust(firewallsValue.AttributeTypes(ctx), map[string]attr.Value{
-				"id":             types.StringValue(*f.Id),
-				"location":       types.StringValue(*f.Location),
-				"name":           types.StringValue(*f.Name),
-				"description":    types.StringValue(*f.Description),
+				"id":             types.StringPointerValue(f.Id),
+				"location":       types.StringPointerValue(f.Location),
+				"name":           types.StringPointerValue(f.Name),
+				"description":    types.StringPointerValue(f.Description),
 				"firewall_rules": fwRules,
 			})
 			firewallsValues = append(firewallsValues, fw)

--- a/internal/provider/firewall_rule_datasource.go
+++ b/internal/provider/firewall_rule_datasource.go
@@ -94,12 +94,12 @@ func GetFirewallRulesState(ctx context.Context, firewallRules *[]ubicloud_client
 	// Firewalls
 	var firewallRulesValues []datasource_vm.FirewallRulesValue
 	firewallRulesValue := datasource_vm.FirewallRulesValue{}
-	if *firewallRules != nil && len(*firewallRules) > 0 {
+	if firewallRules != nil && len(*firewallRules) > 0 {
 		for _, r := range *firewallRules {
 			fr := datasource_vm.NewFirewallRulesValueMust(firewallRulesValue.AttributeTypes(ctx), map[string]attr.Value{
-				"id":         types.StringValue(*r.Id),
-				"cidr":       types.StringValue(*r.Cidr),
-				"port_range": types.StringValue(*r.PortRange),
+				"id":         types.StringPointerValue(r.Id),
+				"cidr":       types.StringPointerValue(r.Cidr),
+				"port_range": types.StringPointerValue(r.PortRange),
 			})
 			firewallRulesValues = append(firewallRulesValues, fr)
 		}

--- a/internal/provider/postgres_datasource.go
+++ b/internal/provider/postgres_datasource.go
@@ -118,11 +118,11 @@ func GetPostgresFirewallRulesState(ctx context.Context, firewallRules *[]ubiclou
 
 	firewallRulesValue := datasource_postgres.FirewallRulesValue{}
 	var firewallRulesValues []datasource_postgres.FirewallRulesValue
-	if *firewallRules != nil && len(*firewallRules) > 0 {
+	if firewallRules != nil && len(*firewallRules) > 0 {
 		for _, r := range *firewallRules {
 			fr := datasource_postgres.NewFirewallRulesValueMust(firewallRulesValue.AttributeTypes(ctx), map[string]attr.Value{
-				"id":   types.StringValue(*r.Id),
-				"cidr": types.StringValue(*r.Cidr),
+				"id":   types.StringPointerValue(r.Id),
+				"cidr": types.StringPointerValue(r.Cidr),
 			})
 			firewallRulesValues = append(firewallRulesValues, fr)
 		}

--- a/internal/provider/private_subnet_datasource.go
+++ b/internal/provider/private_subnet_datasource.go
@@ -115,14 +115,14 @@ func GetNicsState(ctx context.Context, nics *[]ubicloud_client.Nic) (basetypes.L
 	var diags diag.Diagnostics
 	nicsValue := datasource_private_subnet.NicsValue{}
 	var nicsValues []datasource_private_subnet.NicsValue
-	if *nics != nil && len(*nics) > 0 {
+	if nics != nil && len(*nics) > 0 {
 		for _, n := range *nics {
 			nv := datasource_private_subnet.NewNicsValueMust(nicsValue.AttributeTypes(ctx), map[string]attr.Value{
-				"id":           types.StringValue(*n.Id),
-				"name":         types.StringValue(*n.Name),
-				"private_ipv4": types.StringValue(*n.PrivateIpv4),
-				"private_ipv6": types.StringValue(*n.PrivateIpv6),
-				"vm_name":      types.StringValue(*n.VmName),
+				"id":           types.StringPointerValue(n.Id),
+				"name":         types.StringPointerValue(n.Name),
+				"private_ipv4": types.StringPointerValue(n.PrivateIpv4),
+				"private_ipv6": types.StringPointerValue(n.PrivateIpv6),
+				"vm_name":      types.StringPointerValue(n.VmName),
 			})
 			nicsValues = append(nicsValues, nv)
 		}


### PR DESCRIPTION
`StringPointerValue` properly handles nil values.

For NICs retrieved via API it's possible that the `vm_name` field is null, see https://github.com/ubicloud/ubicloud/blob/2c7862fcbc5010d4efff4aebcb96200fd123cf1e/serializers/nic.rb#L10. 

In internal/provider/private_subnet_datasource.go we do the following assignment without properly checking for nil values. 
```golang
"vm_name": types.StringValue(*n.VmName),
```

In this PR, we switch from `StringValue`  to `StringPointerValue` for this and related fields as it properly handles nil values. Even though these other fields should never be null it's safer to still perform this check, e.g., in case the Ubicloud API goes through changes.

Acceptance tests have passed: https://github.com/ubicloud/terraform-provider-ubicloud/actions/runs/12128505573