### PR TITLE
Skip test TestAccProjectResource

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,4 +9,4 @@ install: build
 	go install -v ./...
 
 testacc:
-	TF_ACC=1 go test ./internal/provider/ -count=1 -v -cover -timeout 10m
+	TF_ACC=1 go test ./internal/provider/ -count=1 -v -cover -timeout 10m -skip TestAccProjectResource


### PR DESCRIPTION
Ubicloud's API can now be accessed with a personal access token, which has advantages over the user-based token received from the login API. One limitation of personal access tokens is that they are project scoped. Creating new projects fails with a 403 when authenticated with a personal access token, which is expected. As `TestAccProjectResource` creates/destroys project it is disabled by default so that the whole test suite passes with personal access tokens. `TestAccProjectResource` can still be manually run as necessary.

With this change GH actions "Acceptance Tests", which now use a personal access token, are passing:
https://github.com/ubicloud/terraform-provider-ubicloud/actions/runs/12432563463